### PR TITLE
Fix for #4153

### DIFF
--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -40,12 +40,12 @@ function showTooltip(element) {
 }
 
 function hideTooltip(element) {
-	d.querySelectorAll('.tooltip').forEach((tooltip)=>{
-		tooltip.classList.remove("visible");
-		d.body.removeChild(tooltip);
-	});
-	// restore title
-	element.setAttribute("title", element.getAttribute("data-title"));
+			d.querySelectorAll('.tooltip').forEach((tooltip)=>{
+				tooltip.classList.remove("visible");
+				d.body.removeChild(tooltip);
+			});
+			// restore title
+			element.setAttribute("title", element.getAttribute("data-title"));
 }
 
 function tooltip(cont = null) {

--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -14,41 +14,57 @@ function isN(n)     { return !isNaN(parseFloat(n)) && isFinite(n); } // isNumber
 function isF(n)     { return n === +n && n !== (n|0); } // isFloat
 function isI(n)     { return n === +n && n === (n|0); } // isInteger
 function toggle(el) { gId(el).classList.toggle("hide"); gId('No'+el).classList.toggle("hide"); }
-function tooltip(cont=null) {
+function showTooltip(element) {
+	// save title
+	element.setAttribute("data-title", element.getAttribute("title"));
+	const tooltip = d.createElement("span");
+	tooltip.className = "tooltip";
+	tooltip.textContent = element.getAttribute("title");
+
+	// prevent default title popup
+	element.removeAttribute("title");
+
+	let { top, left, width } = element.getBoundingClientRect();
+
+	d.body.appendChild(tooltip);
+
+	const { offsetHeight, offsetWidth } = tooltip;
+
+	const offset = element.classList.contains("sliderwrap") ? 4 : 10;
+	top -= offsetHeight + offset;
+	left += (width - offsetWidth) / 2;
+
+	tooltip.style.top = top + "px";
+	tooltip.style.left = left + "px";
+	tooltip.classList.add("visible");
+}
+
+function hideTooltip(element) {
+	d.querySelectorAll('.tooltip').forEach((tooltip)=>{	
+		tooltip.classList.remove("visible");
+		d.body.removeChild(tooltip);
+	});
+	// restore title
+	element.setAttribute("title", element.getAttribute("data-title"));
+}
+
+function tooltip(cont=null)
+{
 	d.querySelectorAll((cont?cont+" ":"")+"[title]").forEach((element)=>{
 		element.addEventListener("mouseover", ()=>{
-			// save title
-			element.setAttribute("data-title", element.getAttribute("title"));
-			const tooltip = d.createElement("span");
-			tooltip.className = "tooltip";
-			tooltip.textContent = element.getAttribute("title");
-
-			// prevent default title popup
-			element.removeAttribute("title");
-
-			let { top, left, width } = element.getBoundingClientRect();
-
-			d.body.appendChild(tooltip);
-
-			const { offsetHeight, offsetWidth } = tooltip;
-
-			const offset = element.classList.contains("sliderwrap") ? 4 : 10;
-			top -= offsetHeight + offset;
-			left += (width - offsetWidth) / 2;
-
-			tooltip.style.top = top + "px";
-			tooltip.style.left = left + "px";
-			tooltip.classList.add("visible");
+			// On touch devices, the "mouseover" event is triggered after "touchend".
+            // Whitout "if (!element.classList.contains("isTouched"))", this would cause the tooltip to appear and never close. 
+			if (!element.classList.contains("isTouched")) { showTooltip(element); } 
+			element.classList.remove("isTouched");
 		});
 
-		element.addEventListener("mouseout", ()=>{
-			d.querySelectorAll('.tooltip').forEach((tooltip)=>{
-				tooltip.classList.remove("visible");
-				d.body.removeChild(tooltip);
-			});
-			// restore title
-			element.setAttribute("title", element.getAttribute("data-title"));
+		element.addEventListener("touchstart", ()=>{
+			element.classList.add("isTouched");
+			showTooltip(element);
 		});
+
+		element.addEventListener("mouseout", ()=>{ hideTooltip(element); });
+		element.addEventListener("touchend", ()=>{ hideTooltip(element); });
 	});
 };
 // https://www.educative.io/edpresso/how-to-dynamically-load-a-js-file-in-javascript

--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -15,32 +15,32 @@ function isF(n)     { return n === +n && n !== (n|0); } // isFloat
 function isI(n)     { return n === +n && n === (n|0); } // isInteger
 function toggle(el) { gId(el).classList.toggle("hide"); gId('No'+el).classList.toggle("hide"); }
 function showTooltip(element) {
-	// save title
-	element.setAttribute("data-title", element.getAttribute("title"));
-	const tooltip = d.createElement("span");
-	tooltip.className = "tooltip";
-	tooltip.textContent = element.getAttribute("title");
+			// save title
+			element.setAttribute("data-title", element.getAttribute("title"));
+			const tooltip = d.createElement("span");
+			tooltip.className = "tooltip";
+			tooltip.textContent = element.getAttribute("title");
 
-	// prevent default title popup
-	element.removeAttribute("title");
+			// prevent default title popup
+			element.removeAttribute("title");
 
-	let { top, left, width } = element.getBoundingClientRect();
+			let { top, left, width } = element.getBoundingClientRect();
 
-	d.body.appendChild(tooltip);
+			d.body.appendChild(tooltip);
 
-	const { offsetHeight, offsetWidth } = tooltip;
+			const { offsetHeight, offsetWidth } = tooltip;
 
-	const offset = element.classList.contains("sliderwrap") ? 4 : 10;
-	top -= offsetHeight + offset;
-	left += (width - offsetWidth) / 2;
+			const offset = element.classList.contains("sliderwrap") ? 4 : 10;
+			top -= offsetHeight + offset;
+			left += (width - offsetWidth) / 2;
 
-	tooltip.style.top = top + "px";
-	tooltip.style.left = left + "px";
-	tooltip.classList.add("visible");
+			tooltip.style.top = top + "px";
+			tooltip.style.left = left + "px";
+			tooltip.classList.add("visible");
 }
 
 function hideTooltip(element) {
-	d.querySelectorAll('.tooltip').forEach((tooltip)=>{	
+	d.querySelectorAll('.tooltip').forEach((tooltip)=>{
 		tooltip.classList.remove("visible");
 		d.body.removeChild(tooltip);
 	});
@@ -49,7 +49,7 @@ function hideTooltip(element) {
 }
 
 function tooltip(cont = null) {
-	let isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+	const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
 	d.querySelectorAll((cont ? cont + " " : "") + "[title]").forEach((element) => {
 		if (isTouchDevice) {
 			element.addEventListener("touchstart", () => { showTooltip(element); });
@@ -59,7 +59,7 @@ function tooltip(cont = null) {
 			element.addEventListener("mouseout", () => { hideTooltip(element); });
 		}
 	});
-}
+};
 // https://www.educative.io/edpresso/how-to-dynamically-load-a-js-file-in-javascript
 function loadJS(FILE_URL, async = true, preGetV = undefined, postGetV = undefined) {
 	let scE = d.createElement("script");

--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -14,7 +14,9 @@ function isN(n)     { return !isNaN(parseFloat(n)) && isFinite(n); } // isNumber
 function isF(n)     { return n === +n && n !== (n|0); } // isFloat
 function isI(n)     { return n === +n && n === (n|0); } // isInteger
 function toggle(el) { gId(el).classList.toggle("hide"); gId('No'+el).classList.toggle("hide"); }
-function showTooltip(element) {
+function tooltip(cont=null) {
+	d.querySelectorAll((cont?cont+" ":"")+"[title]").forEach((element)=>{
+		element.addEventListener("pointerover", ()=>{
 			// save title
 			element.setAttribute("data-title", element.getAttribute("title"));
 			const tooltip = d.createElement("span");
@@ -37,27 +39,16 @@ function showTooltip(element) {
 			tooltip.style.top = top + "px";
 			tooltip.style.left = left + "px";
 			tooltip.classList.add("visible");
-}
+		});
 
-function hideTooltip(element) {
+		element.addEventListener("pointerout", ()=>{
 			d.querySelectorAll('.tooltip').forEach((tooltip)=>{
 				tooltip.classList.remove("visible");
 				d.body.removeChild(tooltip);
 			});
 			// restore title
 			element.setAttribute("title", element.getAttribute("data-title"));
-}
-
-function tooltip(cont = null) {
-	const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-	d.querySelectorAll((cont ? cont + " " : "") + "[title]").forEach((element) => {
-		if (isTouchDevice) {
-			element.addEventListener("touchstart", () => { showTooltip(element); });
-			element.addEventListener("touchend", () => { hideTooltip(element); });
-		} else {
-			element.addEventListener("mouseover", () => { showTooltip(element); });
-			element.addEventListener("mouseout", () => { hideTooltip(element); });
-		}
+		});
 	});
 };
 // https://www.educative.io/edpresso/how-to-dynamically-load-a-js-file-in-javascript

--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -48,25 +48,18 @@ function hideTooltip(element) {
 	element.setAttribute("title", element.getAttribute("data-title"));
 }
 
-function tooltip(cont=null)
-{
-	d.querySelectorAll((cont?cont+" ":"")+"[title]").forEach((element)=>{
-		element.addEventListener("mouseover", ()=>{
-			// On touch devices, the "mouseover" event is triggered after "touchend".
-            // Whitout "if (!element.classList.contains("isTouched"))", this would cause the tooltip to appear and never close. 
-			if (!element.classList.contains("isTouched")) { showTooltip(element); } 
-			element.classList.remove("isTouched");
-		});
-
-		element.addEventListener("touchstart", ()=>{
-			element.classList.add("isTouched");
-			showTooltip(element);
-		});
-
-		element.addEventListener("mouseout", ()=>{ hideTooltip(element); });
-		element.addEventListener("touchend", ()=>{ hideTooltip(element); });
+function tooltip(cont = null) {
+	let isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+	d.querySelectorAll((cont ? cont + " " : "") + "[title]").forEach((element) => {
+		if (isTouchDevice) {
+			element.addEventListener("touchstart", () => { showTooltip(element); });
+			element.addEventListener("touchend", () => { hideTooltip(element); });
+		} else {
+			element.addEventListener("mouseover", () => { showTooltip(element); });
+			element.addEventListener("mouseout", () => { hideTooltip(element); });
+		}
 	});
-};
+}
 // https://www.educative.io/edpresso/how-to-dynamically-load-a-js-file-in-javascript
 function loadJS(FILE_URL, async = true, preGetV = undefined, postGetV = undefined) {
 	let scE = d.createElement("script");

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -3111,32 +3111,32 @@ function mergeDeep(target, ...sources)
 }
 
 function showTooltip(element) {
-	// save title
-	element.setAttribute("data-title", element.getAttribute("title"));
-	const tooltip = d.createElement("span");
-	tooltip.className = "tooltip";
-	tooltip.textContent = element.getAttribute("title");
+			// save title
+			element.setAttribute("data-title", element.getAttribute("title"));
+			const tooltip = d.createElement("span");
+			tooltip.className = "tooltip";
+			tooltip.textContent = element.getAttribute("title");
 
-	// prevent default title popup
-	element.removeAttribute("title");
+			// prevent default title popup
+			element.removeAttribute("title");
 
-	let { top, left, width } = element.getBoundingClientRect();
+			let { top, left, width } = element.getBoundingClientRect();
 
-	d.body.appendChild(tooltip);
+			d.body.appendChild(tooltip);
 
-	const { offsetHeight, offsetWidth } = tooltip;
+			const { offsetHeight, offsetWidth } = tooltip;
 
-	const offset = element.classList.contains("sliderwrap") ? 4 : 10;
-	top -= offsetHeight + offset;
-	left += (width - offsetWidth) / 2;
+			const offset = element.classList.contains("sliderwrap") ? 4 : 10;
+			top -= offsetHeight + offset;
+			left += (width - offsetWidth) / 2;
 
-	tooltip.style.top = top + "px";
-	tooltip.style.left = left + "px";
-	tooltip.classList.add("visible");
+			tooltip.style.top = top + "px";
+			tooltip.style.left = left + "px";
+			tooltip.classList.add("visible");
 }
 
 function hideTooltip(element) {
-	d.querySelectorAll('.tooltip').forEach((tooltip)=>{	
+	d.querySelectorAll('.tooltip').forEach((tooltip)=>{
 		tooltip.classList.remove("visible");
 		d.body.removeChild(tooltip);
 	});
@@ -3145,7 +3145,7 @@ function hideTooltip(element) {
 }
 
 function tooltip(cont = null) {
-	let isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+	const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
 	d.querySelectorAll((cont ? cont + " " : "") + "[title]").forEach((element) => {
 		if (isTouchDevice) {
 			element.addEventListener("touchstart", () => { showTooltip(element); });
@@ -3155,7 +3155,7 @@ function tooltip(cont = null) {
 			element.addEventListener("mouseout", () => { hideTooltip(element); });
 		}
 	});
-}
+};
 
 // Transforms the default UI into the simple UI
 function simplifyUI() {

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -3110,7 +3110,9 @@ function mergeDeep(target, ...sources)
 	return mergeDeep(target, ...sources);
 }
 
-function showTooltip(element) {
+function tooltip(cont=null) {
+	d.querySelectorAll((cont?cont+" ":"")+"[title]").forEach((element)=>{
+		element.addEventListener("pointerover", ()=>{
 			// save title
 			element.setAttribute("data-title", element.getAttribute("title"));
 			const tooltip = d.createElement("span");
@@ -3133,27 +3135,16 @@ function showTooltip(element) {
 			tooltip.style.top = top + "px";
 			tooltip.style.left = left + "px";
 			tooltip.classList.add("visible");
-}
+		});
 
-function hideTooltip(element) {
+		element.addEventListener("pointerout", ()=>{
 			d.querySelectorAll('.tooltip').forEach((tooltip)=>{
 				tooltip.classList.remove("visible");
 				d.body.removeChild(tooltip);
 			});
 			// restore title
 			element.setAttribute("title", element.getAttribute("data-title"));
-}
-
-function tooltip(cont = null) {
-	const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-	d.querySelectorAll((cont ? cont + " " : "") + "[title]").forEach((element) => {
-		if (isTouchDevice) {
-			element.addEventListener("touchstart", () => { showTooltip(element); });
-			element.addEventListener("touchend", () => { hideTooltip(element); });
-		} else {
-			element.addEventListener("mouseover", () => { showTooltip(element); });
-			element.addEventListener("mouseout", () => { hideTooltip(element); });
-		}
+		});
 	});
 };
 

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -3110,42 +3110,57 @@ function mergeDeep(target, ...sources)
 	return mergeDeep(target, ...sources);
 }
 
+function showTooltip(element) {
+	// save title
+	element.setAttribute("data-title", element.getAttribute("title"));
+	const tooltip = d.createElement("span");
+	tooltip.className = "tooltip";
+	tooltip.textContent = element.getAttribute("title");
+
+	// prevent default title popup
+	element.removeAttribute("title");
+
+	let { top, left, width } = element.getBoundingClientRect();
+
+	d.body.appendChild(tooltip);
+
+	const { offsetHeight, offsetWidth } = tooltip;
+
+	const offset = element.classList.contains("sliderwrap") ? 4 : 10;
+	top -= offsetHeight + offset;
+	left += (width - offsetWidth) / 2;
+
+	tooltip.style.top = top + "px";
+	tooltip.style.left = left + "px";
+	tooltip.classList.add("visible");
+}
+
+function hideTooltip(element) {
+	d.querySelectorAll('.tooltip').forEach((tooltip)=>{	
+		tooltip.classList.remove("visible");
+		d.body.removeChild(tooltip);
+	});
+	// restore title
+	element.setAttribute("title", element.getAttribute("data-title"));
+}
+
 function tooltip(cont=null)
 {
 	d.querySelectorAll((cont?cont+" ":"")+"[title]").forEach((element)=>{
 		element.addEventListener("mouseover", ()=>{
-			// save title
-			element.setAttribute("data-title", element.getAttribute("title"));
-			const tooltip = d.createElement("span");
-			tooltip.className = "tooltip";
-			tooltip.textContent = element.getAttribute("title");
-
-			// prevent default title popup
-			element.removeAttribute("title");
-
-			let { top, left, width } = element.getBoundingClientRect();
-
-			d.body.appendChild(tooltip);
-
-			const { offsetHeight, offsetWidth } = tooltip;
-
-			const offset = element.classList.contains("sliderwrap") ? 4 : 10;
-			top -= offsetHeight + offset;
-			left += (width - offsetWidth) / 2;
-
-			tooltip.style.top = top + "px";
-			tooltip.style.left = left + "px";
-			tooltip.classList.add("visible");
+			// On touch devices, the "mouseover" event is triggered after "touchend".
+            // Whitout "if (!element.classList.contains("isTouched"))", this would cause the tooltip to appear and never close. 
+			if (!element.classList.contains("isTouched")) { showTooltip(element); } 
+			element.classList.remove("isTouched");
 		});
 
-		element.addEventListener("mouseout", ()=>{
-			d.querySelectorAll('.tooltip').forEach((tooltip)=>{
-				tooltip.classList.remove("visible");
-				d.body.removeChild(tooltip);
-			});
-			// restore title
-			element.setAttribute("title", element.getAttribute("data-title"));
+		element.addEventListener("touchstart", ()=>{
+			element.classList.add("isTouched");
+			showTooltip(element);
 		});
+
+		element.addEventListener("mouseout", ()=>{ hideTooltip(element); });
+		element.addEventListener("touchend", ()=>{ hideTooltip(element); });
 	});
 };
 

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -3136,12 +3136,12 @@ function showTooltip(element) {
 }
 
 function hideTooltip(element) {
-		d.querySelectorAll('.tooltip').forEach((tooltip)=>{
-			tooltip.classList.remove("visible");
-			d.body.removeChild(tooltip);
-		});
-		// restore title
-		element.setAttribute("title", element.getAttribute("data-title"));
+			d.querySelectorAll('.tooltip').forEach((tooltip)=>{
+				tooltip.classList.remove("visible");
+				d.body.removeChild(tooltip);
+			});
+			// restore title
+			element.setAttribute("title", element.getAttribute("data-title"));
 }
 
 function tooltip(cont = null) {

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -3144,25 +3144,18 @@ function hideTooltip(element) {
 	element.setAttribute("title", element.getAttribute("data-title"));
 }
 
-function tooltip(cont=null)
-{
-	d.querySelectorAll((cont?cont+" ":"")+"[title]").forEach((element)=>{
-		element.addEventListener("mouseover", ()=>{
-			// On touch devices, the "mouseover" event is triggered after "touchend".
-            // Whitout "if (!element.classList.contains("isTouched"))", this would cause the tooltip to appear and never close. 
-			if (!element.classList.contains("isTouched")) { showTooltip(element); } 
-			element.classList.remove("isTouched");
-		});
-
-		element.addEventListener("touchstart", ()=>{
-			element.classList.add("isTouched");
-			showTooltip(element);
-		});
-
-		element.addEventListener("mouseout", ()=>{ hideTooltip(element); });
-		element.addEventListener("touchend", ()=>{ hideTooltip(element); });
+function tooltip(cont = null) {
+	let isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+	d.querySelectorAll((cont ? cont + " " : "") + "[title]").forEach((element) => {
+		if (isTouchDevice) {
+			element.addEventListener("touchstart", () => { showTooltip(element); });
+			element.addEventListener("touchend", () => { hideTooltip(element); });
+		} else {
+			element.addEventListener("mouseover", () => { showTooltip(element); });
+			element.addEventListener("mouseout", () => { hideTooltip(element); });
+		}
 	});
-};
+}
 
 // Transforms the default UI into the simple UI
 function simplifyUI() {

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -3136,12 +3136,12 @@ function showTooltip(element) {
 }
 
 function hideTooltip(element) {
-	d.querySelectorAll('.tooltip').forEach((tooltip)=>{
-		tooltip.classList.remove("visible");
-		d.body.removeChild(tooltip);
-	});
-	// restore title
-	element.setAttribute("title", element.getAttribute("data-title"));
+		d.querySelectorAll('.tooltip').forEach((tooltip)=>{
+			tooltip.classList.remove("visible");
+			d.body.removeChild(tooltip);
+		});
+		// restore title
+		element.setAttribute("title", element.getAttribute("data-title"));
 }
 
 function tooltip(cont = null) {


### PR DESCRIPTION
Fixes #4153

The issue was caused by the `mouseover` event sometimes being triggered on button release for touch inputs. This resulted in the tooltip appearing but never closing.

I resolved the issue by only adding the `mouseover` and `mouseout` events on devices without touchscreens, 
while the `touchstart` and `touchend` events are loaded for devices with touchscreens.