### PR TITLE
Add IP address to info pane

### DIFF
--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -734,6 +734,7 @@ ${inforow("Free heap",(i.freeheap/1024).toFixed(1)," kB")}
 ${i.psram?inforow("Free PSRAM",(i.psram/1024).toFixed(1)," kB"):""}
 ${inforow("Estimated current",pwru)}
 ${inforow("Average FPS",i.leds.fps)}
+${inforow("IP address",i.ip)}
 ${inforow("MAC address",i.mac)}
 ${inforow("CPU clock",i.clock," MHz")}
 ${inforow("Flash size",i.flash," MB")}


### PR DESCRIPTION
When browsing from a computer by hostname there is no easy way to see the instance IP, could be useful to have it with the rest of the info