### PR TITLE
Fix for: Build should stop if npm fails #4513

### DIFF
--- a/pio-scripts/build_ui.py
+++ b/pio-scripts/build_ui.py
@@ -1,3 +1,21 @@
-Import('env')
+Import("env")
+import shutil
 
-env.Execute("npm run build")
+node_ex = shutil.which("node")
+# Check if Node.js is installed and present in PATH if it failed, abort the build
+if node_ex is None:
+    print('\x1b[0;31;43m' + 'Node.js is not installed or missing from PATH html css js will not be processed check https://kno.wled.ge/advanced/compiling-wled/' + '\x1b[0m')
+    exitCode = env.Execute("null")
+    exit(exitCode)
+else:
+    # Install the necessary node packages for the pre-build asset bundling script
+    print('\x1b[6;33;42m' + 'Installing node packages' + '\x1b[0m')
+    env.Execute("npm install")
+
+    # Call the bundling script
+    exitCode = env.Execute("npm run build")
+
+    # If it failed, abort the build
+    if (exitCode):
+      print('\x1b[0;31;43m' + 'npm run build fails check https://kno.wled.ge/advanced/compiling-wled/' + '\x1b[0m')
+      exit(exitCode)


### PR DESCRIPTION
Fixes #4513 

This will check if Node,js is present in path and will continue to build WLED 

![node](https://github.com/user-attachments/assets/3e8f9f16-4cd3-422a-a01a-cb855beca9e3)

or it will cancel the build and show error

![node-ex](https://github.com/user-attachments/assets/cec37666-afa8-4ac5-9732-d2a4575de36e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the build process to verify required dependencies before proceeding.
  - Now displays clear error messages if any prerequisites are missing.
  - Ensures a smoother build execution by installing necessary packages only when conditions are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->