### PR TITLE
Bugfix for incorrect wifi-hardware timing

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -760,6 +760,7 @@ void WLED::initConnection()
 #endif
 
   WiFi.disconnect(true); // close old connections
+  delay(5);              // wait for hardware to be ready
 #ifdef ESP8266
   WiFi.setPhyMode(force802_3g ? WIFI_PHY_MODE_11G : WIFI_PHY_MODE_11N);
 #endif


### PR DESCRIPTION
this fixes the AP not initializing on some hardware due to incorrect timing.
Adding this short delay fixes it on tested C3 devices. I did not find any documentation stating how much delay is required.

@blazoncek is there any downside to adding this delay for all devices? The delay is not the cleanest solution, it would be better to check the state of the wifi hardware but I have no idea what to check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced WiFi connection reliability with a brief delay during the initialization process to ensure optimal hardware readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->